### PR TITLE
Feat login page

### DIFF
--- a/src/components/navigation/NavigationComponent.js
+++ b/src/components/navigation/NavigationComponent.js
@@ -11,7 +11,7 @@ export default function NavigationComponent() {
   const renderControlsLoggedIn = token ? <LoggedIn /> : null;
 
   return (
-    <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
+    <Navbar collapseOnSelect expand="lg">
       <Navbar.Brand>Sports Betting</Navbar.Brand>
       <Navbar.Toggle aria-controls="responsive-navbar-nav" />
       <Navbar.Collapse id="responsive-navbar-nav">

--- a/src/components/navigation/NavigationComponent.js
+++ b/src/components/navigation/NavigationComponent.js
@@ -11,8 +11,12 @@ export default function NavigationComponent() {
   const renderControlsLoggedIn = token ? <LoggedIn /> : null;
 
   return (
-    <Navbar collapseOnSelect expand="lg">
-      <Navbar.Brand>Sports Betting</Navbar.Brand>
+    <Navbar
+      collapseOnSelect
+      expand="lg"
+      style={{ boxShadow: "none", backgroundColor: "transparent" }}
+    >
+      <Navbar.Brand style={{ color: "#fff" }}>Sports Betting</Navbar.Brand>
       <Navbar.Toggle aria-controls="responsive-navbar-nav" />
       <Navbar.Collapse id="responsive-navbar-nav">
         {renderControlsLoggedIn}

--- a/src/components/pages/Login.js
+++ b/src/components/pages/Login.js
@@ -30,35 +30,54 @@ export default function Login() {
   }
 
   return (
-    <Container>
-      <Form as={Col} md={{ span: 6, offset: 3 }} className="mt-5">
-        <Form.Group controlId="formBasicEmail">
-          <Form.Label>Emailadres</Form.Label>
-          <Form.Control
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            type="email"
-            placeholder="Vul emailadres in"
-            required
-          />
-        </Form.Group>
+    <container>
+      <div class="row">
+        <div class="col-4" style={{}}>
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum."
+        </div>
 
-        <Form.Group controlId="formBasicPassword">
-          <Form.Label>Wachtwoord</Form.Label>
-          <Form.Control
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            type="password"
-            placeholder="Wachtwoord"
-            required
-          />
-        </Form.Group>
-        <Form.Group className="mt-5">
-          <Button variant="primary" type="submit" onClick={submitForm}>
-            Inloggen
-          </Button>
-        </Form.Group>
-      </Form>
-    </Container>
+        <div
+          class="col-8"
+          style={{
+            minHeight: "calc(100vh - 80px)",
+          }}
+        >
+          <Form as={Col} md={{ span: 6, offset: 3 }} className="mt-5">
+            <Form.Group controlId="formBasicEmail">
+              <Form.Label>Emailadres</Form.Label>
+              <Form.Control
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                type="email"
+                placeholder="Vul emailadres in"
+                required
+              />
+            </Form.Group>
+
+            <Form.Group controlId="formBasicPassword">
+              <Form.Label>Wachtwoord</Form.Label>
+              <Form.Control
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                type="password"
+                placeholder="Wachtwoord"
+                required
+              />
+            </Form.Group>
+            <Form.Group className="mt-5">
+              <Button variant="primary" type="submit" onClick={submitForm}>
+                Inloggen
+              </Button>
+            </Form.Group>
+          </Form>
+        </div>
+      </div>
+    </container>
   );
 }

--- a/src/components/pages/Login.js
+++ b/src/components/pages/Login.js
@@ -30,53 +30,50 @@ export default function Login() {
   }
 
   return (
-    <container>
-      <div class="row">
-        <div class="col-4" style={{}}>
-          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum."
-        </div>
+    <container
+      style={{
+        minHeight: "calc(100vh - 80px)",
+      }}
+    >
+      <div class="col-4" style={{ color: "#fff", marginTop: "30px" }}>
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum."
+      </div>
 
-        <div
-          class="col-8"
-          style={{
-            minHeight: "calc(100vh - 80px)",
-          }}
-        >
-          <Form as={Col} md={{ span: 6, offset: 3 }} className="mt-5">
-            <Form.Group controlId="formBasicEmail">
-              <Form.Label>Emailadres</Form.Label>
-              <Form.Control
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                type="email"
-                placeholder="Vul emailadres in"
-                required
-              />
-            </Form.Group>
+      <div class="col-4 offset-4">
+        <form>
+          <Form.Group controlId="formBasicEmail">
+            <Form.Label>Emailadres</Form.Label>
+            <Form.Control
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              type="email"
+              // placeholder="Vul emailadres in"
+              required
+            />
+          </Form.Group>
 
-            <Form.Group controlId="formBasicPassword">
-              <Form.Label>Wachtwoord</Form.Label>
-              <Form.Control
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                type="password"
-                placeholder="Wachtwoord"
-                required
-              />
-            </Form.Group>
-            <Form.Group className="mt-5">
-              <Button variant="primary" type="submit" onClick={submitForm}>
-                Inloggen
-              </Button>
-            </Form.Group>
-          </Form>
-        </div>
+          <Form.Group controlId="formBasicPassword">
+            <Form.Label>Wachtwoord</Form.Label>
+            <Form.Control
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              type="password"
+              // placeholder="Wachtwoord"
+              required
+            />
+          </Form.Group>
+          <Form.Group className="mt-5">
+            <Button variant="primary" type="submit" onClick={submitForm}>
+              Inloggen
+            </Button>
+          </Form.Group>
+        </form>
       </div>
     </container>
   );

--- a/src/scss/_bootswatch.scss
+++ b/src/scss/_bootswatch.scss
@@ -47,7 +47,8 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&
 
 .navbar {
   border: none;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  background-color: #2581d4;
+  // box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 
   &-brand {
     font-size: 24px;

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -18,7 +18,7 @@ body,
 html {
   height: 100%;
   /* The image used */
-  background-image: url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
+  // background-image: url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
 
   /* Full height */
   height: 100%;

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -20,6 +20,17 @@ html {
   /* The image used */
   // background-image: url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
 
+  background-image: Linear-gradient(
+      120deg,
+      rgba(252, 6, 53, 0.8) 33%,
+      rgba(255, 255, 255, 0.8) 33%,
+      rgba(255, 255, 255, 0.8) 66%,
+      rgba(40, 186, 255, 0.7) 66%
+    ),
+    url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
+  background-size: cover;
+  background-position: top;
+
   /* Full height */
   height: 100%;
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -11,7 +11,7 @@ h1 {
 }
 
 button.btn.btn-primary {
-  background: #903b4b;
+  background: #2581d4;
 }
 
 body,
@@ -21,13 +21,16 @@ html {
   // background-image: url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
 
   background-image: Linear-gradient(
-      120deg,
+      150deg,
       rgba(252, 6, 53, 0.8) 33%,
-      rgba(255, 255, 255, 0.8) 33%,
+      rgba(255, 255, 255, 0.8) 33%
+    ),
+    Linear-gradient(
+      100deg,
       rgba(255, 255, 255, 0.8) 66%,
       rgba(40, 186, 255, 0.7) 66%
-    ),
-    url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
+    );
+  // url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
   background-size: cover;
   background-position: top;
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -23,14 +23,14 @@ html {
   background-image: Linear-gradient(
       150deg,
       rgba(252, 6, 53, 0.8) 33%,
-      rgba(255, 255, 255, 0.8) 33%
+      transparent 33%
     ),
     Linear-gradient(
       100deg,
-      rgba(255, 255, 255, 0.8) 66%,
+      rgba(255, 255, 255, 0.7) 66%,
       rgba(40, 186, 255, 0.7) 66%
-    );
-  // url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
+    ),
+    url("../components/images/soccer-wallpaper-1920x1200-hd-f-WTG200617757.jpg");
   background-size: cover;
   background-position: top;
 


### PR DESCRIPTION
In this section I made a different background.

For this I used the combination of the 'background-image property' with linear-gradient (which one can use in a non-gradient way). You can find this css-declaration in [custom.scss](https://github.com/mipes4/sports-betting-client/compare/feat-login-page?expand=1#diff-d37f597de7a8588e980ffe960c706466) in the body, html block. 

In the [bootswatch-file](https://github.com/mipes4/sports-betting-client/compare/feat-login-page?expand=1#diff-c27e5620f1daa6c31195a2f4c69fa491) I removed the box-shadow (which created the border) and changed the color of the header.

This background will there for all pages of the app. Let us check if this is what we want. 

<img width="1427" alt="Schermafbeelding 2020-08-19 om 05 52 41" src="https://user-images.githubusercontent.com/60842970/90590584-433a3200-e1e1-11ea-9837-c88502249800.png">


