### PR TITLE
Test with jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "testV": "react-scripts test --verbose",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/store/appState/actions.js
+++ b/src/store/appState/actions.js
@@ -19,6 +19,8 @@ export const setMessage = (variant, dismissable, text) => {
   };
 };
 
+/*  This probably should not be a thunk, the dispatch could be a parameter comming from the the function that invokes showMessageWithTimeout and passes the dispatch function as a argument */
+
 export const showMessageWithTimeout = (
   variant,
   dismissable,

--- a/src/store/appState/actions.js
+++ b/src/store/appState/actions.js
@@ -8,7 +8,6 @@ export const CLEAR_MESSAGE = "CLEAR_MESSAGE";
 export const appLoading = () => ({ type: APP_LOADING });
 export const appDoneLoading = () => ({ type: APP_DONE_LOADING });
 export const clearMessage = () => ({ type: CLEAR_MESSAGE });
-
 export const setMessage = (variant, dismissable, text) => {
   return {
     type: SET_MESSAGE,

--- a/src/store/appState/tests/actions.test.js
+++ b/src/store/appState/tests/actions.test.js
@@ -19,8 +19,9 @@ describe("appState", () => {
       type: SET_MESSAGE,
       payload: { variant, dismissable, text },
     };
-    test("should return an object containing type and payload", () => {
+    test("should return an object with type and payload", () => {
       expect(setMessage(variant, dismissable, text)).toEqual(expected);
+      expect(setMessage(variant, dismissable, text).type).toBe(SET_MESSAGE);
       expect(setMessage(variant, dismissable, text).payload).toEqual(
         expected.payload
       );
@@ -44,6 +45,16 @@ describe("appState", () => {
       expect(appLoading()).toEqual(expected);
       expect(appLoading().type).toBe(APP_LOADING);
       expect(appLoading().payload).toBeUndefined;
+    });
+  });
+  describe("#appDoneLoading", () => {
+    const expected = {
+      type: APP_DONE_LOADING,
+    };
+    test("should return an object with type and no payload", () => {
+      expect(appDoneLoading()).toEqual(expected);
+      expect(appDoneLoading().type).toBe(APP_DONE_LOADING);
+      expect(appDoneLoading().payload).toBeUndefined;
     });
   });
 });

--- a/src/store/appState/tests/actions.test.js
+++ b/src/store/appState/tests/actions.test.js
@@ -26,4 +26,14 @@ describe("appState", () => {
       );
     });
   });
+  describe("#clearMessage", () => {
+    const expected = {
+      type: CLEAR_MESSAGE,
+    };
+    test("should return an action object with type and no payload", () => {
+      expect(clearMessage()).toEqual(expected);
+      expect(clearMessage().type).toBe(CLEAR_MESSAGE);
+      expect(clearMessage().payload).toBeUndefined;
+    });
+  });
 });

--- a/src/store/appState/tests/actions.test.js
+++ b/src/store/appState/tests/actions.test.js
@@ -58,3 +58,5 @@ describe("appState", () => {
     });
   });
 });
+
+/* To do: test showMessageWithTimeout. For this the functions probably needs to be converterd in to a normal function instead of being a thunk. */

--- a/src/store/appState/tests/actions.test.js
+++ b/src/store/appState/tests/actions.test.js
@@ -30,10 +30,20 @@ describe("appState", () => {
     const expected = {
       type: CLEAR_MESSAGE,
     };
-    test("should return an action object with type and no payload", () => {
+    test("should return an object with type and no payload", () => {
       expect(clearMessage()).toEqual(expected);
       expect(clearMessage().type).toBe(CLEAR_MESSAGE);
       expect(clearMessage().payload).toBeUndefined;
+    });
+  });
+  describe("#appLoading", () => {
+    const expected = {
+      type: APP_LOADING,
+    };
+    test("should return an object with type and no payload", () => {
+      expect(appLoading()).toEqual(expected);
+      expect(appLoading().type).toBe(APP_LOADING);
+      expect(appLoading().payload).toBeUndefined;
     });
   });
 });

--- a/src/store/appState/tests/actions.test.js
+++ b/src/store/appState/tests/actions.test.js
@@ -1,0 +1,29 @@
+import {
+  APP_LOADING,
+  APP_DONE_LOADING,
+  CLEAR_MESSAGE,
+  SET_MESSAGE,
+  appLoading,
+  appDoneLoading,
+  clearMessage,
+  setMessage,
+  showMessageWithTimeout,
+} from "../actions";
+
+describe("appState", () => {
+  describe("#setMessage", () => {
+    const variant = "success";
+    const dismissable = true;
+    const text = "test_text";
+    const expected = {
+      type: SET_MESSAGE,
+      payload: { variant, dismissable, text },
+    };
+    test("should return an object containing type and payload", () => {
+      expect(setMessage(variant, dismissable, text)).toEqual(expected);
+      expect(setMessage(variant, dismissable, text).payload).toEqual(
+        expected.payload
+      );
+    });
+  });
+});

--- a/src/store/appState/tests/reducer.test.js
+++ b/src/store/appState/tests/reducer.test.js
@@ -1,5 +1,5 @@
 import reducer from "../reducer";
-import { APP_LOADING } from "../actions";
+import { APP_LOADING, APP_DONE_LOADING } from "../actions";
 
 describe("appStateReducer", () => {
   const initialState = {
@@ -12,6 +12,14 @@ describe("appStateReducer", () => {
       const newState = reducer(initialState, action);
       expect(newState).toEqual({ loading: true, message: null });
       expect(newState.loading).toBe(true);
+    });
+  });
+  describe("when given APP_DONE_LOADING action type", () => {
+    test("returns a new state with loading set to false", () => {
+      const action = { type: APP_DONE_LOADING };
+      const newState = reducer(initialState, action);
+      expect(newState).toEqual({ loading: false, message: null });
+      expect(newState.loading).toBe(false);
     });
   });
 });

--- a/src/store/appState/tests/reducer.test.js
+++ b/src/store/appState/tests/reducer.test.js
@@ -6,53 +6,55 @@ import {
   SET_MESSAGE,
 } from "../actions";
 
-describe("appStateReducer", () => {
-  describe("if given no state and a random action", () => {
+describe("#appStateReducer", () => {
+  describe("with no state and a random action", () => {
     const initialState = {
       loading: false,
       message: null,
     };
-    test("returns the inital state", () => {
+    test("should return the inital state", () => {
       const newState = reducer(undefined, { type: APP_DONE_LOADING });
       expect(newState).toEqual(initialState);
+      expect(newState.loading).toBe(false);
       expect(newState.message).toBeNull;
     });
-    test("returns the inital state", () => {
+    test("should return the inital state", () => {
       const newState = reducer(undefined, { type: APP_LOADING });
+      expect(newState).not.toEqual(initialState);
       expect(newState.loading).toBe(true);
       expect(newState.message).toBeNull;
     });
   });
-  describe("when given APP_LOADING action type", () => {
+  describe("#APP_LOADING action type", () => {
     const initialState = {
       loading: false,
       message: null,
     };
-    test("returns a new state with loading set to true", () => {
+    test("should return a new state with loading set to true", () => {
       const action = { type: APP_LOADING };
       const newState = reducer(initialState, action);
       expect(newState).toEqual({ loading: true, message: null });
       expect(newState.loading).toBe(true);
     });
   });
-  describe("when given APP_DONE_LOADING action type", () => {
+  describe("#APP_DONE_LOADING action type", () => {
     const initialState = {
       loading: false,
       message: null,
     };
-    test("returns a new state with loading set to false", () => {
+    test("should return a new state with loading set to false", () => {
       const action = { type: APP_DONE_LOADING };
       const newState = reducer(initialState, action);
       expect(newState).toEqual({ loading: false, message: null });
       expect(newState.loading).toBe(false);
     });
   });
-  describe("when given a CLEAR_MESSAGE action type", () => {
+  describe("#CLEAR_MESSAGE action type", () => {
     const state = {
       loading: true,
       message: "test_message",
     };
-    test("returns a new state with the message set to null", () => {
+    test("should return a new state with the message set to null", () => {
       const action = { type: CLEAR_MESSAGE };
       const newState = reducer(state, action);
       expect(newState).toEqual({ loading: true, message: null });
@@ -60,7 +62,7 @@ describe("appStateReducer", () => {
       expect(newState.loading).toBe(true);
     });
   });
-  describe("when given a SET_MESSAGE action type", () => {
+  describe("#SET_MESSAGE action type", () => {
     const state = {
       loading: true,
       message: null,
@@ -72,16 +74,16 @@ describe("appStateReducer", () => {
       type: SET_MESSAGE,
       payload: { variant, dismissable, text },
     };
-    test("returns a new state with the payload containing correct values", () => {
+    test("should return a new state with the payload containing correct values", () => {
       const newState = reducer(state, action);
       expect(newState).toEqual({
         loading: true,
         message: action.payload,
       });
       expect(newState.message).toBe(action.payload);
-      expect(newState.message.variant).toBe("success");
+      expect(newState.message.variant).toBe(variant);
       expect(newState.message.dismissable).toBe(true);
-      expect(newState.message.text).toBe("test_message");
+      expect(newState.message.text).toBe(text);
       expect(newState.loading).toBe(true);
     });
   });

--- a/src/store/appState/tests/reducer.test.js
+++ b/src/store/appState/tests/reducer.test.js
@@ -6,6 +6,18 @@ describe("appStateReducer", () => {
     loading: false,
     message: null,
   };
+  describe("if given no state and a random action", () => {
+    test("returns the inital state", () => {
+      const newState = reducer(undefined, { type: APP_DONE_LOADING });
+      expect(newState).toEqual(initialState);
+      expect(newState.message).toBeNull;
+    });
+    test("returns the inital state", () => {
+      const newState = reducer(undefined, { type: APP_LOADING });
+      expect(newState.loading).toBe(true);
+      expect(newState.message).toBeNull;
+    });
+  });
   describe("when given APP_LOADING action type", () => {
     test("returns a new state with loading set to true", () => {
       const action = { type: APP_LOADING };

--- a/src/store/appState/tests/reducer.test.js
+++ b/src/store/appState/tests/reducer.test.js
@@ -1,0 +1,17 @@
+import reducer from "../reducer";
+import { APP_LOADING } from "../actions";
+
+describe("appStateReducer", () => {
+  const initialState = {
+    loading: false,
+    message: null,
+  };
+  describe("when given APP_LOADING action type", () => {
+    test("returns a new state with loading set to true", () => {
+      const action = { type: APP_LOADING };
+      const newState = reducer(initialState, action);
+      expect(newState).toEqual({ loading: true, message: null });
+      expect(newState.loading).toBe(true);
+    });
+  });
+});

--- a/src/store/appState/tests/reducer.test.js
+++ b/src/store/appState/tests/reducer.test.js
@@ -1,5 +1,10 @@
 import reducer from "../reducer";
-import { APP_LOADING, APP_DONE_LOADING, CLEAR_MESSAGE } from "../actions";
+import {
+  APP_LOADING,
+  APP_DONE_LOADING,
+  CLEAR_MESSAGE,
+  SET_MESSAGE,
+} from "../actions";
 
 describe("appStateReducer", () => {
   describe("if given no state and a random action", () => {
@@ -52,6 +57,31 @@ describe("appStateReducer", () => {
       const newState = reducer(state, action);
       expect(newState).toEqual({ loading: true, message: null });
       expect(newState.message).toBeNull;
+      expect(newState.loading).toBe(true);
+    });
+  });
+  describe("when given a SET_MESSAGE action type", () => {
+    const state = {
+      loading: true,
+      message: null,
+    };
+    const variant = "success";
+    const dismissable = true;
+    const text = "test_message";
+    const action = {
+      type: SET_MESSAGE,
+      payload: { variant, dismissable, text },
+    };
+    test("returns a new state with the payload containing correct values", () => {
+      const newState = reducer(state, action);
+      expect(newState).toEqual({
+        loading: true,
+        message: action.payload,
+      });
+      expect(newState.message).toBe(action.payload);
+      expect(newState.message.variant).toBe("success");
+      expect(newState.message.dismissable).toBe(true);
+      expect(newState.message.text).toBe("test_message");
       expect(newState.loading).toBe(true);
     });
   });

--- a/src/store/appState/tests/reducer.test.js
+++ b/src/store/appState/tests/reducer.test.js
@@ -1,12 +1,12 @@
 import reducer from "../reducer";
-import { APP_LOADING, APP_DONE_LOADING } from "../actions";
+import { APP_LOADING, APP_DONE_LOADING, CLEAR_MESSAGE } from "../actions";
 
 describe("appStateReducer", () => {
-  const initialState = {
-    loading: false,
-    message: null,
-  };
   describe("if given no state and a random action", () => {
+    const initialState = {
+      loading: false,
+      message: null,
+    };
     test("returns the inital state", () => {
       const newState = reducer(undefined, { type: APP_DONE_LOADING });
       expect(newState).toEqual(initialState);
@@ -19,6 +19,10 @@ describe("appStateReducer", () => {
     });
   });
   describe("when given APP_LOADING action type", () => {
+    const initialState = {
+      loading: false,
+      message: null,
+    };
     test("returns a new state with loading set to true", () => {
       const action = { type: APP_LOADING };
       const newState = reducer(initialState, action);
@@ -27,11 +31,28 @@ describe("appStateReducer", () => {
     });
   });
   describe("when given APP_DONE_LOADING action type", () => {
+    const initialState = {
+      loading: false,
+      message: null,
+    };
     test("returns a new state with loading set to false", () => {
       const action = { type: APP_DONE_LOADING };
       const newState = reducer(initialState, action);
       expect(newState).toEqual({ loading: false, message: null });
       expect(newState.loading).toBe(false);
+    });
+  });
+  describe("when given a CLEAR_MESSAGE action type", () => {
+    const state = {
+      loading: true,
+      message: "test_message",
+    };
+    test("returns a new state with the message set to null", () => {
+      const action = { type: CLEAR_MESSAGE };
+      const newState = reducer(state, action);
+      expect(newState).toEqual({ loading: true, message: null });
+      expect(newState.message).toBeNull;
+      expect(newState.loading).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Tests for the appState-slice (actions, reducer) of the Redux store.
I removed the general `app.test.js`. This file won't be missed now and can be added back later.

To run the tests: in your terminal run `npm run test` or `npm run testV` for a more verbose version.

The thunk in `appState/actions.js`: `setMessageWithTimeout` needs some attention. It could be that this shouldn't be a thunk. 
Now thunks are chained, e.g. when a user logs in (a thunk) it dispatches another thunk: `showMessageWithTimeout`. This cannot be tested properly. 
To be investigated/continued.
